### PR TITLE
Switch to Swarm Configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+image: tiangolo/docker-with-compose
+
+before_script:
+  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+
+stages:
+  - build
+  - deploy
+
+build-prod:
+  stage: build
+  script:
+    - docker-compose build
+  only:
+    - master
+
+deploy-prod:
+  stage: deploy
+  script:
+    - docker stack deploy -c docker-compose.yml --with-registry-auth $(echo $CI_PROJECT_NAME | sed 's/-docker//')
+  only:
+    - master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,23 @@ version: '3'
 services:
   bitwarden:
     image: mprasil/bitwarden:alpine
-    restart: always
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
     volumes:
       - /opt/data/bitwarden:/data/
     env_file:
       - yubico.env
     networks:
-      - traefik
-      - default
+      - service-default
     labels:
       - "traefik.enable=true"
       - "traefik.domain=bitwarden.serubin.net"
       - "traefik.frontend.rule=Host: bitwarden.serubin.net"
-      - "traefik.docker.network=traefik"
+      - "traefik.docker.network=service-default"
       - "traefik.port=80"
 
 networks:
-  traefik:
+  service-default:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     env_file:
       - yubico.env
     networks:
+      - default
       - service-default
     labels:
       - "traefik.enable=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,14 +15,15 @@ services:
       - yubico.env
     networks:
       - default
-      - service-default
+      - traefik-public
     labels:
       - "traefik.enable=true"
       - "traefik.domain=bitwarden.serubin.net"
       - "traefik.frontend.rule=Host: bitwarden.serubin.net"
-      - "traefik.docker.network=service-default"
+      - "traefik.tags=traefik-public"
+      - "traefik.docker.network=traefik-public"
       - "traefik.port=80"
 
 networks:
-  service-default:
+  traefik-public:
     external: true


### PR DESCRIPTION
## Description

Switch to swarm configuration for bitwarden. This is an easy starting point as it's low risk and we can test ci/cd.